### PR TITLE
Fix lua errors when fighting enemies with a nil value for UnitClass()

### DIFF
--- a/SP_SwingTimer.lua
+++ b/SP_SwingTimer.lua
@@ -306,7 +306,7 @@ local function CheckDamageSource(dmg, dmgType)
 			['Mage']	= 1923,
 		};
 		local unitClass = UnitClass("target");
-		local armor = basearmor[unitClass];
+		local armor = unitClass and basearmor[unitClass] or basearmor['Warrior'];
 		for i=1,16 do
 			debuffTexture, debuffApplications = UnitDebuff("target", i);
 			if (has_value(armorDebuffs,debuffTexture)) then


### PR DESCRIPTION
I found the custom target dummies are like this on turtle wow, perhaps more custom mobs. I suppose 2006 retail and other unmodded private servers never had classless enemies, and so players and prior developers never ran into this error.